### PR TITLE
Authenticate access token

### DIFF
--- a/app/controllers/oauth/user_info_controller.rb
+++ b/app/controllers/oauth/user_info_controller.rb
@@ -1,58 +1,22 @@
 module Oauth
   class UserInfoController < ApplicationController
     skip_before_action :verify_authenticity_token
-    before_action :authenticate_bearer_token
-    rescue_from ArgumentError, with: :handle_argument_error
 
     def show
+      validator = BearerTokenValidator.new(request.headers["Authorization"])
+      @current_user = validator.validate_and_get_user
+
       user_info = {
         sub: @current_user.id.to_s,
         first_name: @current_user.first_name,
         last_name: @current_user.last_name,
         email: @current_user.email
       }
-
       render json: user_info
-    end
-
-    private
-
-    def handle_argument_error(e)
+    rescue ArgumentError => e
       render json: { error: e.message }, status: :unauthorized
-    end
-
-    def authenticate_bearer_token
-      validate_auth_header
-      token = get_bearer_token_from_headers
-      access_token = validate_access_token(token)
-      set_current_user(access_token)
-    end
-
-    def validate_auth_header
-      auth_header = request.headers["Authorization"]
-      raise ArgumentError, "Missing authorization header" if auth_header.blank?
-      raise ArgumentError, "Invalid authorization header" unless auth_header.start_with?("Bearer ")
-    end
-
-    # token comes in this format "Bearer hashcodehere", this method removes "Bearer" and the space after and just returns the hash
-    def get_bearer_token_from_headers
-      request.headers["Authorization"].gsub("Bearer ", "")
-    end
-
-    def validate_access_token(token)
-      raise ArgumentError, "Missing access token" if token.blank?
-      access_token = AccessToken.find_by(token: token)
-      raise ArgumentError, "Invalid access token" if access_token.nil?
-      raise ArgumentError, "Access token expired" if access_token.expired?
-
-      access_token
-    end
-
-    # gets the user from the access token association to user via the user_id foreign key.
-    def set_current_user(access_token)
-      @current_user = access_token.user
-
-      raise ArgumentError, "User not found" if @current_user.nil?
+    rescue ActiveRecord::RecordNotFound
+      render json: { error: "User not found" }, status: :not_found
     end
   end
 end

--- a/app/controllers/oauth/user_info_controller.rb
+++ b/app/controllers/oauth/user_info_controller.rb
@@ -43,7 +43,7 @@ module Oauth
       raise ArgumentError, "Missing access token" if token.blank?
       access_token = AccessToken.find_by(token: token)
       raise ArgumentError, "Invalid access token" if access_token.nil?
-      raise ArgumentError, "Access token expired" if access_token.expired
+      raise ArgumentError, "Access token expired" if access_token.expired?
 
       access_token
     end

--- a/app/controllers/oauth/user_info_controller.rb
+++ b/app/controllers/oauth/user_info_controller.rb
@@ -1,0 +1,58 @@
+module Oauth
+  class UserInfoController < ApplicationController
+    skip_before_action :verify_authenticity_token
+    before_action :authenticate_bearer_token
+    rescue_from ArgumentError, with: :handle_argument_error
+
+    def show
+      user_info = {
+        sub: @current_user.id.to_s,
+        first_name: @current_user.first_name,
+        last_name: @current_user.last_name,
+        email: @current_user.email
+      }
+
+      render json: user_info
+    end
+
+    private
+
+    def handle_argument_error(e)
+      render json: { error: e.message }, status: :unauthorized
+    end
+
+    def authenticate_bearer_token
+      validate_auth_header
+      token = get_bearer_token_from_headers
+      access_token = validate_access_token(token)
+      set_current_user(access_token)
+    end
+
+    def validate_auth_header
+      auth_header = request.headers["Authorization"]
+      raise ArgumentError, "Missing authorization header" if auth_header.blank?
+      raise ArgumentError, "Invalid authorization header" unless auth_header.start_with?("Bearer ")
+    end
+
+    # token comes in this format "Bearer hashcodehere", this method removes "Bearer" and the space after and just returns the hash
+    def get_bearer_token_from_headers
+      request.headers["Authorization"].gsub("Bearer ", "")
+    end
+
+    def validate_access_token(token)
+      raise ArgumentError, "Missing access token" if token.blank?
+      access_token = AccessToken.find_by(token: token)
+      raise ArgumentError, "Invalid access token" if access_token.nil?
+      raise ArgumentError, "Access token expired" if access_token.expired
+
+      access_token
+    end
+
+    # gets the user from the access token association to user via the user_id foreign key.
+    def set_current_user(access_token)
+      @current_user = access_token.user
+
+      raise ArgumentError, "User not found" if @current_user.nil?
+    end
+  end
+end

--- a/app/services/bearer_token_validator.rb
+++ b/app/services/bearer_token_validator.rb
@@ -1,0 +1,40 @@
+class BearerTokenValidator
+  attr_reader :authorization_header
+
+  def initialize(authorization_header)
+    @authorization_header = authorization_header
+  end
+
+  def validate_and_get_user
+    validate_authorization_header
+    token = extract_bearer_token
+    access_token = validate_access_token(token)
+    get_user_from_token(access_token)
+  end
+
+  private
+
+  def validate_authorization_header
+    raise ArgumentError, "Missing authorization header" if authorization_header.blank?
+    raise ArgumentError, "Invalid authorization header" unless authorization_header.start_with?("Bearer ")
+  end
+
+  def extract_bearer_token
+    token = authorization_header.gsub("Bearer ", "")
+    raise ArgumentError, "Missing access token" if token.blank?
+    token
+  end
+
+  def validate_access_token(token)
+    access_token = AccessToken.find_by(token:)
+    raise ArgumentError, "Invalid access token" if access_token.nil?
+    raise ArgumentError, "Access token expired" if access_token.expired?
+    access_token
+  end
+
+  def get_user_from_token(access_token)
+    user = access_token.user
+    raise ArgumentError, "User not found" if user.nil?
+    user
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   namespace :oauth do
     get "authorize", to: "oauth#authorize"
     post "token", to: "oauth#token"
+    get "userinfo", to: "user_info#show"
   end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/spec/requests/user_info_controller_spec.rb
+++ b/spec/requests/user_info_controller_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Oauth::UserInfoController, type: :request do
       client_id: '123',
       client_name: 'Rubber Toes',
       redirect_uri: 'https://www.robert.com/callback',
-      client_secret: 'safe'
     )
   }
 

--- a/spec/requests/user_info_controller_spec.rb
+++ b/spec/requests/user_info_controller_spec.rb
@@ -26,6 +26,14 @@ RSpec.describe Oauth::UserInfoController, type: :request do
       expires_at: 1.hour.from_now
     )
   }
+  let(:expired_access_token) {
+    AccessToken.create!(
+      token: "exp123",
+      oauth_client: valid_client,
+      user: valid_user,
+      expires_at: 1.hour.ago
+    )
+  }
 
   def make_request(token: valid_access_token.token)
     headers = {}

--- a/spec/requests/user_info_controller_spec.rb
+++ b/spec/requests/user_info_controller_spec.rb
@@ -1,0 +1,115 @@
+require 'rails_helper'
+
+RSpec.describe Oauth::UserInfoController, type: :request do
+  let(:valid_client) {
+    OauthClient.create!(
+      client_id: '123',
+      client_name: 'Rubber Toes',
+      redirect_uri: 'https://www.robert.com/callback',
+      client_secret: 'safe'
+    )
+  }
+
+  let(:valid_user) {
+    User.create!(
+      email: 'robert@gmail.com',
+      first_name: 'robert',
+      last_name: 'rodriguez'
+    )
+  }
+
+  let(:valid_access_token) {
+    AccessToken.create!(
+      token: AccessToken.generate_token,
+      oauth_client: valid_client,
+      user: valid_user,
+      expires_at: 1.hour.from_now
+    )
+  }
+
+  def make_request(token: valid_access_token.token)
+    headers = {}
+    headers['Authorization'] = "Bearer #{token}" if token
+    get oauth_userinfo_path, headers: headers
+  end
+
+  describe 'GET /oauth/userinfo' do
+    shared_examples 'an unauthorized request' do
+      it 'returns an :unauthorized status' do
+        make_request(**request_params)
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it 'returns a JSON response with the error message' do
+        make_request(**request_params)
+        expect(JSON.parse(response.body)['error']).to eq(error_message)
+      end
+    end
+
+    context 'when request is valid' do
+      it 'returns user info with required fields' do
+        make_request
+        expect(response).to have_http_status(200)
+
+        json = JSON.parse(response.body)
+        expect(json).to have_key('sub')
+        expect(json).to have_key('first_name')
+        expect(json).to have_key('last_name')
+        expect(json).to have_key('email')
+      end
+
+      it 'returns correct user data' do
+        make_request
+        json = JSON.parse(response.body)
+
+        expect(json['sub']).to eq(valid_user.id.to_s)
+        expect(json['first_name']).to eq(valid_user.first_name)
+        expect(json['last_name']).to eq(valid_user.last_name)
+        expect(json['email']).to eq(valid_user.email)
+      end
+
+      it 'sets correct content type' do
+        make_request
+        expect(response.content_type).to include('application/json')
+      end
+    end
+
+    context 'when request is invalid' do
+      context 'when Authorization header is missing' do
+        let(:request_params) { { token: nil } }
+        let(:error_message) { 'Missing authorization header' }
+        it_behaves_like 'an unauthorized request'
+      end
+
+      context 'when Authorization header does not use Bearer scheme' do
+        it 'returns unauthorized with proper error message' do
+          get oauth_userinfo_path, headers: { 'Authorization' => 'Basic invalid_scheme' }
+          expect(response).to have_http_status(:unauthorized)
+          expect(JSON.parse(response.body)['error']).to eq('Invalid authorization header')
+        end
+      end
+
+      context 'when Authorization header is incorrect' do
+        it 'returns unauthorized when missing Bearer prefix' do
+          get oauth_userinfo_path, headers: { 'Authorization' => 'abc123' }
+          expect(response).to have_http_status(:unauthorized)
+          expect(JSON.parse(response.body)['error']).to eq('Invalid authorization header')
+        end
+      end
+
+      context 'when access token is missing' do
+        it 'returns unauthorized when token is empty after Bearer' do
+          get oauth_userinfo_path, headers: { 'Authorization' => 'Bearer ' }
+          expect(response).to have_http_status(:unauthorized)
+          expect(JSON.parse(response.body)['error']).to eq('Missing access token')
+        end
+      end
+
+      context 'when access token is invalid' do
+        let(:request_params) { { token: 'invalid_token_123' } }
+        let(:error_message) { 'Invalid access token' }
+        it_behaves_like 'an unauthorized request'
+      end
+    end
+  end
+end

--- a/spec/services/bearer_token_validator_spec.rb
+++ b/spec/services/bearer_token_validator_spec.rb
@@ -1,0 +1,127 @@
+require 'rails_helper'
+
+RSpec.describe BearerTokenValidator do
+  let(:valid_client) {
+    OauthClient.create!(
+      client_id: '123',
+      client_name: 'capsule corp',
+      redirect_uri: 'https://cc.com/callback'
+    )
+  }
+
+  let(:valid_user) {
+    User.create!(
+      email: 'robert@gmail.com',
+      first_name: 'robert',
+      last_name: 'rod'
+    )
+  }
+
+  let(:valid_access_token) {
+    AccessToken.create!(
+      token: AccessToken.generate_token,
+      oauth_client: valid_client,
+      user: valid_user,
+      expires_at: 1.hour.from_now
+    )
+  }
+
+  let(:expired_access_token) {
+    AccessToken.create!(
+      token: 'expired',
+      oauth_client: valid_client,
+      user: valid_user,
+      expires_at: 1.hour.ago
+    )
+  }
+
+  describe '#validate_and_get_user' do
+    context 'when authorization header is valid' do
+      let(:authorization_header) { "Bearer #{valid_access_token.token}" }
+      subject { described_class.new(authorization_header).validate_and_get_user }
+
+      it 'returns the user' do
+        expect(subject).to eq(valid_user)
+      end
+    end
+
+    context 'when authorization header is missing' do
+      let(:authorization_header) { nil }
+      subject { described_class.new(authorization_header).validate_and_get_user }
+
+      it 'raises ArgumentError with correct message' do
+        expect { subject }.to raise_error(ArgumentError, 'Missing authorization header')
+      end
+    end
+
+    context 'when authorization header is blank' do
+      let(:authorization_header) { '' }
+      subject { described_class.new(authorization_header).validate_and_get_user }
+
+      it 'raises ArgumentError with correct message' do
+        expect { subject }.to raise_error(ArgumentError, 'Missing authorization header')
+      end
+    end
+
+    context 'when authorization header does not start with Bearer' do
+      let(:authorization_header) { 'Basic abc123' }
+      subject { described_class.new(authorization_header).validate_and_get_user }
+
+      it 'raises ArgumentError with correct message' do
+        expect { subject }.to raise_error(ArgumentError, 'Invalid authorization header')
+      end
+    end
+
+    context 'when authorization header is missing Bearer prefix' do
+      let(:authorization_header) { 'abc123' }
+      subject { described_class.new(authorization_header).validate_and_get_user }
+
+      it 'raises ArgumentError with correct message' do
+        expect { subject }.to raise_error(ArgumentError, 'Invalid authorization header')
+      end
+    end
+
+    context 'when token is missing after Bearer' do
+      let(:authorization_header) { 'Bearer ' }
+      subject { described_class.new(authorization_header).validate_and_get_user }
+
+      it 'raises ArgumentError with correct message' do
+        expect { subject }.to raise_error(ArgumentError, 'Missing access token')
+      end
+    end
+
+    context 'when access token does not exist' do
+      let(:authorization_header) { 'Bearer invalid_token_123' }
+      subject { described_class.new(authorization_header).validate_and_get_user }
+
+      it 'raises ArgumentError with correct message' do
+        expect { subject }.to raise_error(ArgumentError, 'Invalid access token')
+      end
+    end
+
+    context 'when access token is expired' do
+      let(:authorization_header) { "Bearer #{expired_access_token.token}" }
+      subject { described_class.new(authorization_header).validate_and_get_user }
+
+      it 'raises ArgumentError with correct message' do
+        expect { subject }.to raise_error(ArgumentError, 'Access token expired')
+      end
+    end
+
+    context 'when user associated with token does not exist' do
+      let(:access_token_without_user) {
+        AccessToken.create!(
+          token: 'token_without_user',
+          oauth_client: valid_client,
+          user: nil,
+          expires_at: 1.hour.from_now
+        )
+      }
+      let(:authorization_header) { "Bearer #{access_token_without_user.token}" }
+      subject { described_class.new(authorization_header).validate_and_get_user }
+
+      it 'raises ArgumentError with correct message' do
+        expect { subject }.to raise_error(ActiveRecord::RecordInvalid, 'Validation failed: User must exist')      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
This PR handles adding an `oauth/userinfo` GET endpoint
- requires a Bearer token in order to access user info
- responds with user info

## Related issue(s)

[Authenticate Access token](https://trello.com/c/EU44RxTh/6-authenticate-access-token)

> create a user info route, use access token to get user data that is protected, implement relation from access token to user

- user relation was already created [prior to this work](https://github.com/robertbylight/simple-oauth-server/pull/8), so its not included in this PR.

## Testing done

### Manual testing 
#### Set up:
- [ ] run `bundle install`
- [ ] if you've reviewed this project before, you'll need to run `rails db:drop`, and `rails db:create` before running `rails db:migrate` since this work changes the schema
- [ ] run migrate command `rails db:migrate`
- [ ] start up server `bin/rails server`
- [ ] open console `bin/rails console`
- [ ] create a client, copy and paste this code snippet into console. 
```
OauthClient.create(
          client_id: 'abc123',
          client_name: 'pr robert client',
          redirect_uri: 'https://www.prrobert.com/callback',
        )
```
you should get a response like this from the console
```
#<OauthClient:0x0000000119f59280
 id: 1,
 client_id: "abc123",
 client_name: "pr robert client",
 redirect_uri: "https://www.prrobert.com/callback",
 created_at: "2025-08-21 18:25:31.487443000 +0000",
 updated_at: "2025-08-21 18:25:31.487443000 +0000"> 
```
- [ ] create a user,  copy and paste this code snippet into console. 

```
    User.create!(
      email: 'robert@gmail.com',
      first_name: 'robert',
      last_name: 'rodriguez'
    )
```
you should get a response like this from the console
```
#<User:0x0000000119a59348
 id: 1,
 email: "[FILTERED]",
 first_name: "robert",
 last_name: "rodriguez",
 created_at: "2025-08-21 18:25:51.861504000 +0000",
 updated_at: "2025-08-21 18:25:51.861504000 +0000"> 
```

#### Successful request:
note: use https://tonyxu-io.github.io/pkce-generator/ to get a code challenge_value used in step 1 and code verifyer used in step 2
note: use this site to get the code challenge and code verifyer: https://tonyxu-io.github.io/pkce-generator/ 
##### Step 1
- [ ]  first get state token from server, perform a GET request using endpoint(use code challenge generated in pkce generator website): `http://localhost:3000/oauth/authorize?client_id=abc123&response_type=code&redirect_uri=https://www.prrobert.com/callback&user_id=1&code_challenge=9lw-fUEobNKcKeV2G1dA-vOxAFTGNOl5K1_o4Kj5_4Y&code_challenge_method=S256` and receive a response that should look like this but with a different state value 
```
{
    "consent_info": {
        "client_name": "pr robert client",
        "user_name": "robert rodriguez",
        "requested_permissions": [
            "First name",
            "Last name",
            "Access your email address"
        ],
        "state": "c0d1bb2e9388f949ee90e38b889617ef2588087333c5d310de25267049950e43",
        "decision_options": {
            "allow": {
                "body": {
                    "state": "c0d1bb2e9388f949ee90e38b889617ef2588087333c5d310de25267049950e43",
                    "decision": "allow"
                }
            },
            "deny": {
                "body": {
                    "state": "c0d1bb2e9388f949ee90e38b889617ef2588087333c5d310de25267049950e43",
                    "decision": "deny"
                }
            }
        }
    }
}
```
##### Step 2 : grant authorization
- [ ] give permission to app by using this POST endpoint `http://localhost:3000/oauth/consent` add this header `Content-Type: application/json`, and this request body but replace the state value with the one you received in step 2:
```
{
    "state": "ed33fb11e19a4e827749dc3b7d5c695a7d93984b758deeae10dfb77a6246f901",
    "decision": "allow"
}
```
you should receive this response:
```
{
    "redirect_url": "https://www.prrobert.com/callback?code=40a693ccf477380ccd11a5d7c72e2985addb1d5fe03962fc443af2824b77cf2f"
}
```
- [ ] Step 3: perform a POST request using endpoint `http://localhost:3000/oauth/token`, make sure you have `Content-Type` header as `application/json`, then copy this json and paste it into the request body. 
- 
copy auth code from response and replace the code shown in the request body snipped below, so from your response above you would only copy the value for code. ie from above response you would copy `2ae47a4a7df52862a9233ec681f69a7a53fd7561cd79363386ce41ca7eab8597`

request body:
```
{
  "grant_type": "authorization_code",
  "code": "47cc4418534f3e2b99afb086fa7fc36e36c1378addb81c25aff67107811d6047",
  "client_id": "abc123",
  "code_verifier": "KdiwRYqb5Ef0h-2BeUCqPJR-d91U2nqIMLEKE7Jebw4"
}
```
you should get a response similar to this( your expires in time may vary):
```
{
    "access_token": "7fbda7974b6b0fe0fff33bda1c469dad61344975aaf118b23f1d83af20d26aa0",
    "token_type": "Bearer",
    "expires_in": 3599
}
```
- [ ]step 4: then prepare a GET route using endpoint `http://localhost:3000/oauth/userinfo` then if your using postman, go to the authorization tab, then go to the auth type drop down list, select "bearer token" and paste the access token into the token field. Then make the call and you should receive a response that looks like this
```
{"sub":"1","first_name":"robert","last_name":"rodriguez","email":"robert@gmail.com"}
```

#### Bad requests
- [ ] Perform the GET request with an incorrect access token, using endpoint `http://localhost:3000/oauth/userinfo`
copy this text into your token field
```
badtoken
```
 you should receive a 401 unathorized response that looks like this
```
   {"error":"Invalid access token"}
```
- [ ] Perform the GET request with an access token thats missing the Bearer prefix, using endpoint `http://localhost:3000/oauth/userinfo`
On postman go to the authorization tab and on the auth type drop down list, select the "no auth" option, then go to the haders tab and type Authorization into a new key, and in the key field paste the valid access token received from the successful request section, and make the call.

 you should receive a 401 unathorized response that looks like this
```
   {"error":"Invalid authorization header"}
```
- [ ] Perform the GET request with an access token thats uses a different prefix, using endpoint `http://localhost:3000/oauth/userinfo`
Go back to the same call made right before this one and in the Authorization key paste `Basic ` note: also copy the space after the word basic.

 you should receive a 401 unathorized response that looks like this
```
   {"error":"Invalid authorization header"}
```
- [ ] Perform the GET request without an access token, using endpoint `http://localhost:3000/oauth/userinfo`. On postman go to the authorization tab and on the auth type drop down list, select the "no auth" option. Make sure you don't have any Authorization headers in your headers tab, if you do uncheck them. Then make the call
 you should receive a 401 unathorized response that looks like this
```
{"error":"Missing authorization header"}
```

#### running tests using Rspec
open terminal and cd into cloned repo and run these commands
- [ ] test for controller `rspec spec/requests/user_info_controller_spec.rb`
- [ ] test for access token model `rspec spec/models/access_token_spec.rb`
- [ ] run all tests `rspec`

## Screenshots
n/a
## What areas of the site does it impact?
n/a
## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback
Im not too familiar with the conventions for Oauth, so please let me know if something in this PR deviates from convention even if its not necessary to request a change for it.