### PR TITLE
Add pkce

### DIFF
--- a/app/controllers/oauth/oauth_controller.rb
+++ b/app/controllers/oauth/oauth_controller.rb
@@ -6,7 +6,11 @@ module Oauth
       validate_authorization_request(params)
 
       current_user = User.find(params[:user_id])
-      code = oauth_client(params[:client_id]).create_authorization_code!(params[:redirect_uri], current_user)
+      code = oauth_client(params[:client_id]).create_authorization_code!(
+        params[:redirect_uri],
+        current_user,
+        params[:code_challenge]
+      )
       redirect_url = build_redirect_url(params[:redirect_uri], { code: })
       render json: { redirect_url: }
     rescue ArgumentError => e
@@ -24,6 +28,9 @@ module Oauth
       raise ArgumentError, "Missing redirect_uri" if params[:redirect_uri].blank?
       raise ArgumentError, "Invalid redirect_uri" unless oauth_client(params[:client_id]).redirect_uri == params[:redirect_uri]
       raise ArgumentError, "Missing user_id" if params[:user_id].blank?
+      raise ArgumentError, "Missing code_challenge" if params[:code_challenge].blank?
+      raise ArgumentError, "Missing code_challenge_method" if params[:code_challenge_method].blank?
+      raise ArgumentError, "Invalid code_challenge_method" unless params[:code_challenge_method] == "S256"
     end
 
     def oauth_client(client_id)

--- a/app/models/oauth_client.rb
+++ b/app/models/oauth_client.rb
@@ -6,7 +6,7 @@ class OauthClient < ApplicationRecord
   validates :client_name, presence: true
   validates :redirect_uri, presence: true
 
-  def create_authorization_code!(redirect_uri, user)
+  def create_authorization_code!(redirect_uri, user, code_challenge)
     user.give_authorization_to_client(self) unless user.is_client_authorized(self)
     code = SecureRandom.hex(32)
 
@@ -17,6 +17,7 @@ class OauthClient < ApplicationRecord
         client_id:,
         user_id: user.id,
         redirect_uri:,
+        code_challenge:,
         created_at: Time.current.iso8601
       }.to_json
     )

--- a/app/services/pkce_validator.rb
+++ b/app/services/pkce_validator.rb
@@ -1,0 +1,11 @@
+class PkceValidator
+  def self.validate(code_challenge, code_verifier)
+    return false if code_challenge.blank? || code_verifier.blank?
+
+    generated_challenge = Base64.urlsafe_encode64(
+      Digest::SHA256.digest(code_verifier)
+    ).tr("=", "")
+
+    generated_challenge == code_challenge
+  end
+end

--- a/app/services/pkce_validator.rb
+++ b/app/services/pkce_validator.rb
@@ -3,8 +3,9 @@ class PkceValidator
     return false if code_challenge.blank? || code_verifier.blank?
 
     generated_challenge = Base64.urlsafe_encode64(
-      Digest::SHA256.digest(code_verifier)
-    ).tr("=", "")
+      Digest::SHA256.digest(code_verifier),
+      padding: false
+    )
 
     generated_challenge == code_challenge
   end

--- a/spec/models/oauth_client_spec.rb
+++ b/spec/models/oauth_client_spec.rb
@@ -4,18 +4,14 @@ RSpec.describe OauthClient, type: :model do
   let(:client_id) { '123' }
   let(:client_name) { 'robert' }
   let(:redirect_uri) { 'http://robert.com/callback' }
-  let(:oauth_client) { create_oauth_client(client_id, client_name, redirect_uri) }
-
-  def create_oauth_client(client_id, client_name, redirect_uri)
-    OauthClient.new(client_id:, client_name:, redirect_uri:)
-  end
+  let(:oauth_client) { OauthClient.new(client_id:, client_name:, redirect_uri:) }
 
   let(:user) { User.create!(email: 'robert@gmail.com', first_name: 'robert', last_name: 'rodriguez') }
 
   describe 'Validations' do
     context 'when attributes are valid' do
       it 'creates a valid oauth client' do
-        expect(oauth_client.valid?).to be_truthy
+        expect(oauth_client).to be_valid
       end
     end
 
@@ -24,7 +20,7 @@ RSpec.describe OauthClient, type: :model do
         let(:client_id) { nil }
 
         it 'is invalid' do
-          expect(oauth_client.valid?).to be_falsy
+          expect(oauth_client).not_to be_valid
           expect(oauth_client.errors[:client_id]).to include("can't be blank")
         end
       end
@@ -33,7 +29,7 @@ RSpec.describe OauthClient, type: :model do
         let(:client_name) { nil }
 
         it 'is invalid' do
-          expect(oauth_client.valid?).to be_falsy
+          expect(oauth_client).not_to be_valid
           expect(oauth_client.errors[:client_name]).to include("can't be blank")
         end
       end
@@ -42,7 +38,7 @@ RSpec.describe OauthClient, type: :model do
         let(:redirect_uri) { nil }
 
         it 'is invalid' do
-          expect(oauth_client.valid?).to be_falsy
+          expect(oauth_client).not_to be_valid
           expect(oauth_client.errors[:redirect_uri]).to include("can't be blank")
         end
       end
@@ -55,22 +51,52 @@ RSpec.describe OauthClient, type: :model do
         before do
           OauthClient.create(client_id: 'abc', client_name: 'obi wan systems', redirect_uri: 'http://obiwansys.com/callback')
         end
+
         it 'is invalid' do
-          expect(oauth_client.valid?).to be_falsy
+          expect(oauth_client).not_to be_valid
           expect(oauth_client.errors[:client_id]).to include("has already been taken")
         end
       end
     end
   end
 
-  describe 'create_authorization_code' do
+  describe 'create_authorization_code!' do
     let(:client_name) { 'megacity' }
     let(:redirect_uri) { 'http://thematrix.com/callback' }
+    let(:code_challenge) { 'abc123' }
 
     it 'creates a valid authorization code' do
-      code = oauth_client.create_authorization_code!(oauth_client.redirect_uri, user)
+      code = oauth_client.create_authorization_code!(oauth_client.redirect_uri, user, code_challenge)
       # regex to match the pattern of the code(64 lowercase alphanumeric characters). does not compare the actual value itself.
       expect(code).to match(/\A[a-f0-9]{64}\z/)
+    end
+
+    it 'stores the authorization code data in Redis' do
+      code = oauth_client.create_authorization_code!(oauth_client.redirect_uri, user, code_challenge)
+
+      redis_data = JSON.parse(Redis.current.get("oauth_code:#{code}"))
+
+      expect(redis_data['client_id']).to eq(oauth_client.client_id)
+      expect(redis_data['user_id']).to eq(user.id)
+      expect(redis_data['redirect_uri']).to eq(oauth_client.redirect_uri)
+      expect(redis_data['code_challenge']).to eq(code_challenge)
+      expect(redis_data['created_at']).to be_present
+    end
+
+    it 'authorizes the user for the client if not already authorized' do
+      expect(user.is_client_authorized(oauth_client)).to be false
+
+      oauth_client.create_authorization_code!(oauth_client.redirect_uri, user, code_challenge)
+
+      expect(user.is_client_authorized(oauth_client)).to be true
+    end
+
+    it 'does not create multiple authorizations if user is already authorized' do
+      user.give_authorization_to_client(oauth_client)
+
+      expect {
+        oauth_client.create_authorization_code!(oauth_client.redirect_uri, user, code_challenge)
+      }.not_to change(OauthAuthorization, :count)
     end
   end
 end

--- a/spec/requests/oauth_controller_spec.rb
+++ b/spec/requests/oauth_controller_spec.rb
@@ -17,24 +17,21 @@ RSpec.describe Oauth::OauthController, type: :request do
     )
   }
 
-  let(:code_challenge) { 'abc123' }
-  let(:code_challenge_method) { 'S256' }
-
   def make_request(
     client_id: valid_client.client_id,
     response_type: 'code',
     redirect_uri: valid_client.redirect_uri,
     user_id: valid_user.id,
-    code_challenge: 'abc123',
+    code_challenge: '6iEWvY6Bhyf7cFsAf84zjbeAHO0y0a4QyZqaddmMclw',
     code_challenge_method: 'S256'
   )
     get oauth_authorize_path, params: {
-      client_id: client_id,
-      response_type: response_type,
-      redirect_uri: redirect_uri,
-      user_id: user_id,
-      code_challenge: code_challenge,
-      code_challenge_method: code_challenge_method
+      client_id:,
+      response_type:,
+      redirect_uri:,
+      user_id:,
+      code_challenge:,
+      code_challenge_method:
     }
   end
 

--- a/spec/requests/oauth_controller_spec.rb
+++ b/spec/requests/oauth_controller_spec.rb
@@ -17,8 +17,25 @@ RSpec.describe Oauth::OauthController, type: :request do
     )
   }
 
-  def make_request(client_id: valid_client.client_id, response_type: 'code', redirect_uri: valid_client.redirect_uri, user_id: valid_user.id)
-    get oauth_authorize_path, params: { client_id: client_id, response_type: response_type, redirect_uri: redirect_uri, user_id: user_id }
+  let(:code_challenge) { 'abc123' }
+  let(:code_challenge_method) { 'S256' }
+
+  def make_request(
+    client_id: valid_client.client_id,
+    response_type: 'code',
+    redirect_uri: valid_client.redirect_uri,
+    user_id: valid_user.id,
+    code_challenge: 'abc123',
+    code_challenge_method: 'S256'
+  )
+    get oauth_authorize_path, params: {
+      client_id: client_id,
+      response_type: response_type,
+      redirect_uri: redirect_uri,
+      user_id: user_id,
+      code_challenge: code_challenge,
+      code_challenge_method: code_challenge_method
+    }
   end
 
   describe 'GET /oauth/authorize' do
@@ -92,6 +109,42 @@ RSpec.describe Oauth::OauthController, type: :request do
           make_request(user_id: 777)
           expect(response).to have_http_status(:not_found)
         end
+      end
+
+      context 'when code_challenge is missing' do
+        let(:request_params) { { code_challenge: nil } }
+        let(:error_message) { 'Missing code_challenge' }
+        it_behaves_like 'an invalid request'
+      end
+
+      context 'when code_challenge is blank' do
+        let(:request_params) { { code_challenge: '' } }
+        let(:error_message) { 'Missing code_challenge' }
+        it_behaves_like 'an invalid request'
+      end
+
+      context 'when code_challenge_method is missing' do
+        let(:request_params) { { code_challenge_method: nil } }
+        let(:error_message) { 'Missing code_challenge_method' }
+        it_behaves_like 'an invalid request'
+      end
+
+      context 'when code_challenge_method is blank' do
+        let(:request_params) { { code_challenge_method: '' } }
+        let(:error_message) { 'Missing code_challenge_method' }
+        it_behaves_like 'an invalid request'
+      end
+
+      context 'when code_challenge_method is not S256' do
+        let(:request_params) { { code_challenge_method: 'plain' } }
+        let(:error_message) { 'Invalid code_challenge_method' }
+        it_behaves_like 'an invalid request'
+      end
+
+      context 'when code_challenge_method is invalid' do
+        let(:request_params) { { code_challenge_method: 'SHA1' } }
+        let(:error_message) { 'Invalid code_challenge_method' }
+        it_behaves_like 'an invalid request'
       end
     end
   end

--- a/spec/requests/oauth_controller_spec.rb
+++ b/spec/requests/oauth_controller_spec.rb
@@ -137,12 +137,6 @@ RSpec.describe Oauth::OauthController, type: :request do
         let(:error_message) { 'Invalid code_challenge_method' }
         it_behaves_like 'an invalid request'
       end
-
-      context 'when code_challenge_method is invalid' do
-        let(:request_params) { { code_challenge_method: 'SHA1' } }
-        let(:error_message) { 'Invalid code_challenge_method' }
-        it_behaves_like 'an invalid request'
-      end
     end
   end
 end

--- a/spec/services/pkce_validator_spec.rb
+++ b/spec/services/pkce_validator_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe PkceValidator do
+  describe '.validate' do
+    let(:code_verifier) { 'msibjqawCU_Xz0RNU-uHQq3QKG_Ir_Zw5HBLZmQn8v8' }
+    let(:code_challenge) { '6BOLKGAIt7da4roth_pXMrRdUh9QHe-hqtVSwjU6cps' }
+
+    context 'when code_verifier matches code_challenge' do
+      it 'returns true' do
+        result = described_class.validate(code_challenge, code_verifier)
+        expect(result).to be true
+      end
+    end
+
+    context 'when code_verifier does not match code_challenge' do
+      it 'returns false' do
+        wrong_verifier = 'wrong'
+        result = described_class.validate(code_challenge, wrong_verifier)
+        expect(result).to be false
+      end
+    end
+
+    context 'when code_challenge is blank' do
+      it 'returns false for nil' do
+        result = described_class.validate(nil, code_verifier)
+        expect(result).to be false
+      end
+
+      it 'returns false for empty string' do
+        result = described_class.validate('', code_verifier)
+        expect(result).to be false
+      end
+    end
+
+    context 'when code_verifier is blank' do
+      it 'returns false for nil' do
+        result = described_class.validate(code_challenge, nil)
+        expect(result).to be false
+      end
+
+      it 'returns false for empty string' do
+        result = described_class.validate(code_challenge, '')
+        expect(result).to be false
+      end
+    end
+
+    context 'when both parameters are blank' do
+      it 'returns false' do
+        result = described_class.validate(nil, nil)
+        expect(result).to be false
+      end
+    end
+  end
+end

--- a/spec/services/pkce_validator_spec.rb
+++ b/spec/services/pkce_validator_spec.rb
@@ -25,28 +25,11 @@ RSpec.describe PkceValidator do
         result = described_class.validate(nil, code_verifier)
         expect(result).to be false
       end
-
-      it 'returns false for empty string' do
-        result = described_class.validate('', code_verifier)
-        expect(result).to be false
-      end
     end
 
     context 'when code_verifier is blank' do
       it 'returns false for nil' do
         result = described_class.validate(code_challenge, nil)
-        expect(result).to be false
-      end
-
-      it 'returns false for empty string' do
-        result = described_class.validate(code_challenge, '')
-        expect(result).to be false
-      end
-    end
-
-    context 'when both parameters are blank' do
-      it 'returns false' do
-        result = described_class.validate(nil, nil)
         expect(result).to be false
       end
     end


### PR DESCRIPTION
## Summary
This PR sets up pkce for the authorize endpoint
- updates the authorize endpoint to now require a code challenge and a code challenge method
- removes client secret in favor of pkce flow

## Related issue(s)

[add authorization-grant and pkce to current flow](https://trello.com/c/9UNG25qs/8-add-authorization-grant-to-current-flow)

> 

## Testing done

### Manual testing 
#### Set up:
- [ ] run `bundle install`
- [ ] run migrate command `rails db:migrate`
- [ ] start up server `bin/rails server`
- [ ] open console `bin/rails console`
- [ ] create a client, copy and paste this code snippet into console. 
```
OauthClient.create(
          client_id: 'abc123',
          client_name: 'pr robert client',
          redirect_uri: 'https://www.prrobert.com/callback',
        )
```
you should get a response like this from the console
```
#<OauthClient:0x0000000111cd8770
 id: 1,
 client_id: "abc123",
 client_name: "pr robert client",
 redirect_uri: "https://www.prrobert.com/callback",
 created_at: "2025-08-19 18:55:24.957880000 +0000",
 updated_at: "2025-08-19 18:55:24.957880000 +0000"> 
```
- [ ] create a user,  copy and paste this code snippet into console. 

```
    User.create!(
      email: 'robert@gmail.com',
      first_name: 'robert',
      last_name: 'rodriguez'
    )
```
you should get a response like this from the console
```
#<User:0x00000001125b2f58
 id: 1,
 email: "[FILTERED]",
 first_name: "robert",
 last_name: "rodriguez",
 created_at: "2025-08-19 18:55:59.192401000 +0000",
 updated_at: "2025-08-19 18:55:59.192401000 +0000"> 
```

#### Successful request:
note: use this site to get the code challenge and code verifyer: https://tonyxu-io.github.io/pkce-generator/ 
##### Step 1
- [ ]  get code from server, perform a GET request using endpoint(note: you can use a code challenge generator or just a random string, for now it doesn't matter until the verifier is used, which will be implemented in a later pr): `http://localhost:3000/oauth/authorize?client_id=abc123&response_type=code&redirect_uri=https://www.prrobert.com/callback&user_id=1&code_challenge=47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU&code_challenge_method=S256` and receive a response that should look like this
```
{
    "redirect_url": "https://www.prrobert.com/callback?code=7c4ebdac1c22548f0ea717cdfba4a915a569c87226ec5c7c74d8be0ad85f1df7"
}
```

#### Bad requests
- [ ] Perform the GET request without a code challenge, using endpoint `http://localhost:3000/oauth/authorize?client_id=abc123&response_type=code&redirect_uri=https://www.prrobert.com/callback&user_id=1&code_challenge_method=S256`

 you should receive a 400 baad request response that looks like this
```
{
    "error": "Missing code_challenge"
}
```

- [ ] Perform the GET request without a code challenge method, using endpoint `http://localhost:3000/oauth/authorize?client_id=abc123&response_type=code&redirect_uri=https://www.prrobert.com/callback&user_id=1&code_challenge=6iEWvY6Bhyf7cFsAf84zjbeAHO0y0a4QyZqaddmMclw`

 you should receive a 400 baad request response that looks like this
```
{
    "error": "Missing code_challenge"
}
```

#### running tests using Rspec
open terminal and cd into cloned repo and run these commands
- [ ] test for pkce `rspec spec/services/pkce_validator_spec.rb`
- [ ] test for oauth controller `rspec spec/requests/oauth_controller_spec.rb`
- [ ] test for oauth client `rspec spec/models/oauth_client_spec.rb`
- [ ] run all tests `rspec`

## Requested Feedback
Im not too familiar with the conventions for Oauth, so please let me know if something in this PR deviates from convention even if its not necessary to request a change for it.